### PR TITLE
Add simplified lmodules_v2

### DIFF
--- a/main_v2.py
+++ b/main_v2.py
@@ -1,0 +1,75 @@
+import argparse
+import lightning as L
+
+from utils.lmodules_v2 import LModel, LDataModule
+from utils.lightning_callbacks.generate import GenerateCallback
+
+
+def train(args: argparse.Namespace) -> None:
+    L.seed_everything(42)
+    model = LModel(model=args.model, lr=args.lr)
+    data = LDataModule(
+        model=args.model,
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        dataset=args.dataset,
+    )
+    trainer = L.Trainer(max_epochs=args.epochs, callbacks=[GenerateCallback()])
+    trainer.fit(model, datamodule=data)
+    trainer.save_checkpoint(args.checkpoint)
+
+
+def test(args: argparse.Namespace) -> None:
+    model = LModel.load_from_checkpoint(args.ckpt)
+    data = LDataModule(
+        model=model.hparams["model"],
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        dataset=args.dataset or "stemp",
+    )
+    trainer = L.Trainer(callbacks=[GenerateCallback()])
+    trainer.test(model, datamodule=data)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Minimal train/test script")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    train_p = sub.add_parser("train", help="Train a model")
+    train_p.add_argument("--model", default="gpt2")
+    train_p.add_argument("--dataset", default="stemp")
+    train_p.add_argument("--batch_size", type=int, default=32)
+    train_p.add_argument("--seq_len", type=int, default=128)
+    train_p.add_argument("--epochs", type=int, default=4)
+    train_p.add_argument("--lr", type=float, default=1e-3)
+    train_p.add_argument("--checkpoint", default="model.ckpt")
+
+    test_p = sub.add_parser("test", help="Evaluate a checkpoint")
+    test_p.add_argument("ckpt")
+    test_p.add_argument("--dataset", default=None)
+    test_p.add_argument("--batch_size", type=int, default=32)
+    test_p.add_argument("--seq_len", type=int, default=128)
+    test_p.add_argument("--max_new_tokens", type=int, default=32)
+    test_p.add_argument("--top_k", type=int, default=1)
+    test_p.add_argument("--do_sample", action="store_true")
+    test_p.add_argument(
+        "--gen_mode",
+        default="draft",
+        choices=["draft", "base", "speculative"],
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.cmd == "train":
+        train(args)
+    else:
+        test(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/lmodules_v2.py
+++ b/utils/lmodules_v2.py
@@ -1,0 +1,80 @@
+import lightning as L
+import torch
+from torch.utils.data import DataLoader
+from transformers import AutoModelForCausalLM, AutoTokenizer, DataCollatorForLanguageModeling
+
+from dataloaders import DATASETS
+
+
+class LModel(L.LightningModule):
+    def __init__(self, model: str = "gpt2", lr: float = 1e-3):
+        super().__init__()
+        self.save_hyperparameters()
+        self.model = AutoModelForCausalLM.from_pretrained(model)
+
+    def forward(self, input_ids, labels=None):
+        return self.model(input_ids=input_ids, labels=labels)
+
+    def training_step(self, batch, batch_idx):
+        out = self(**batch)
+        loss = out.loss
+        self.log("train_loss", loss, prog_bar=True)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        out = self(**batch)
+        loss = out.loss
+        self.log("val_loss", loss, prog_bar=True)
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.AdamW(self.parameters(), lr=self.hparams.lr)
+
+
+class LDataModule(L.LightningDataModule):
+    def __init__(
+        self,
+        model: str = "gpt2",
+        batch_size: int = 1,
+        seq_len: int = 32,
+        dataset: str = "stemp",
+        max_num_samples: int | None = None,
+    ):
+        super().__init__()
+        self.tokenizer = AutoTokenizer.from_pretrained(model)
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.batch_size = batch_size
+        self.seq_len = seq_len
+        self.dataset_name = dataset
+        self.max_num_samples = max_num_samples
+
+    def setup(self, stage=None):
+        ds_cls = DATASETS[self.dataset_name]
+        dataset = ds_cls(
+            tokenizer=self.tokenizer,
+            seq_len=self.seq_len,
+            max_num_samples=self.max_num_samples,
+        ).load_data()
+
+        self.train_ds = dataset["train"]
+        self.val_ds = dataset.get("eval") or dataset.get("validation")
+        self.test_ds = dataset.get("test")
+
+    def train_dataloader(self):
+        collator = DataCollatorForLanguageModeling(
+            tokenizer=self.tokenizer, mlm=False, return_tensors="pt"
+        )
+        return DataLoader(self.train_ds, batch_size=self.batch_size, shuffle=True, collate_fn=collator)
+
+    def val_dataloader(self):
+        collator = DataCollatorForLanguageModeling(
+            tokenizer=self.tokenizer, mlm=False, return_tensors="pt"
+        )
+        return DataLoader(self.val_ds, batch_size=self.batch_size, collate_fn=collator)
+
+    def test_dataloader(self):
+        collator = DataCollatorForLanguageModeling(
+            tokenizer=self.tokenizer, mlm=False, return_tensors="pt"
+        )
+        return DataLoader(self.test_ds, batch_size=self.batch_size, collate_fn=collator)


### PR DESCRIPTION
## Summary
- add simplified `lmodules_v2.py`
- add a minimal training entry point `main_v2.py`
- refine simplified modules to use project datasets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684b458c4b38832ab77b4d47367d15e1